### PR TITLE
Update SpineShader.shader

### DIFF
--- a/Assets/Shader/SpineShader.shader
+++ b/Assets/Shader/SpineShader.shader
@@ -8,6 +8,7 @@ SubShader
 {
         Tags {"Queue"="Transparent+2" "IgnoreProjector"="True" "RenderType"="Transparent"}
         ZWrite Off
+        Cull Off
         Blend SrcAlpha OneMinusSrcAlpha
  
         Stencil {


### PR DESCRIPTION
Fix issue with missing image when the image is flipped in spine.

Before:
<img width="70" alt="before" src="https://cloud.githubusercontent.com/assets/282017/9733545/b79eb6ac-565e-11e5-9a83-62f4a2f72929.png">

After
<img width="70" alt="after" src="https://cloud.githubusercontent.com/assets/282017/9733542/b337f86c-565e-11e5-9bfd-884e7daf4b45.png">

